### PR TITLE
update 1510-psi-set-window-icons.diff after changes in upstream

### DIFF
--- a/patches/1510-psi-set-window-icons.diff
+++ b/patches/1510-psi-set-window-icons.diff
@@ -57,22 +57,23 @@ Index: psi/src/avcall/calldlg.cpp
 ===================================================================
 --- psi.orig/src/avcall/calldlg.cpp	2013-01-15 14:04:29.732827171 +0400
 +++ psi/src/avcall/calldlg.cpp	2013-01-15 14:04:29.724827171 +0400
-@@ -26,6 +26,7 @@
+@@ -28,6 +28,7 @@
  #include "common.h"
  #include "psiaccount.h"
  #include "psioptions.h"
 +#include "iconset.h"
-
+ 
  // from opt_avcall.cpp
  extern void options_avcall_update();
-@@ -63,6 +64,7 @@
+@@ -68,6 +69,7 @@ public:
  	{
  		ui.setupUi(q);
  		q->setWindowTitle(tr("Voice Call"));
 +		q->setWindowIcon(IconsetFactory::icon("psi/avcall").icon());
-
+ 
  		ui.lb_bandwidth->setEnabled(false);
  		ui.cb_bandwidth->setEnabled(false);
+
 Index: psi/src/bookmarkmanagedlg.cpp
 ===================================================================
 --- psi.orig/src/bookmarkmanagedlg.cpp	2013-01-15 14:04:29.732827171 +0400


### PR DESCRIPTION
Этот пул реквест имеет смысл принять сразу после изменений в Psi:
https://github.com/psi-im/psi/pull/134
