### PR TITLE
Add provisional systemd support to UnixSystemWatch

### DIFF
--- a/patches/1150-psi-nix-systemwatch.diff
+++ b/patches/1150-psi-nix-systemwatch.diff
@@ -1,6 +1,6 @@
 --- git.temp.orig/src/libpsi/tools/systemwatch/systemwatch_unix.cpp
 +++ git.temp/src/libpsi/tools/systemwatch/systemwatch_unix.cpp
-@@ -19,7 +19,25 @@
+@@ -19,7 +19,42 @@
   */
  
  #include "systemwatch_unix.h"
@@ -11,10 +11,27 @@
  UnixSystemWatch::UnixSystemWatch()
  {
 +#ifdef USE_DBUS
++	// TODO: check which service we should listen to
 +	QDBusConnection conn = QDBusConnection::systemBus();
++	// listen to systemd's logind
++	// TODO: use delaying Inhibitor locks
++	conn.connect("org.freedesktop.login1", "/org/freedesktop/login1", "org.freedesktop.login1.Manager", "PrepareForSleep", this, SLOT(prepareForSleep(bool)));
++	// listen to UPower
 +	conn.connect("org.freedesktop.UPower", "/org/freedesktop/UPower", "org.freedesktop.UPower", "Sleeping", this, SLOT(sleeping()));
 +	conn.connect("org.freedesktop.UPower", "/org/freedesktop/UPower", "org.freedesktop.UPower", "Resuming", this, SLOT(resuming()));
 +#endif
++}
++
++void UnixSystemWatch::prepareForSleep(bool beforeSleep)
++{
++	if (beforeSleep)
++	{
++		emit sleep();
++	}
++	else
++	{
++		emit wakeup();
++	}
 +}
 +
 +void UnixSystemWatch::sleeping()
@@ -28,7 +45,7 @@
  }
 --- git.temp.orig/src/libpsi/tools/systemwatch/systemwatch_unix.h
 +++ git.temp/src/libpsi/tools/systemwatch/systemwatch_unix.h
-@@ -25,8 +25,13 @@
+@@ -25,8 +25,14 @@
  
  class UnixSystemWatch : public SystemWatch
  {
@@ -37,6 +54,7 @@
  	UnixSystemWatch();
 +
 +private slots:
++	void prepareForSleep(bool beforeSleep);
 +	void sleeping();
 +	void resuming();
  };


### PR DESCRIPTION
UPower's sleep/resume signals are deprecated, so listen additionally
to systemd's logind.

Todo:
- Check which service we should actually listen to
- Use delaying Inhibitor locks for systemd
